### PR TITLE
Disable Javascript and external resources in HTML version of email

### DIFF
--- a/src/main/java/io/github/trashemail/TrashEmailFetchMail/utils/SaveMailToHTMLFile.java
+++ b/src/main/java/io/github/trashemail/TrashEmailFetchMail/utils/SaveMailToHTMLFile.java
@@ -18,6 +18,8 @@ public class SaveMailToHTMLFile {
     private static final Logger log = LoggerFactory.getLogger(
             SaveMailToHTMLFile.class);
 
+    private static String safeHTMLCSPPolicy = "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'self';style-src 'unsafe-inline';img-src 'self' data:\">";
+
     public Object saveToFile(String htmlContent){
         try {
             String filename = UUID.randomUUID().toString() + ".html";
@@ -25,7 +27,7 @@ public class SaveMailToHTMLFile {
             FileWriter myWriter = new FileWriter(
                     fetchMailConfig.getEmails().getDownloadPath() + filename);
 
-            myWriter.write(htmlContent);
+            myWriter.write(safeHTMLCSPPolicy + htmlContent);
             myWriter.close();
 
             log.debug("File written to disk: "+ filename);


### PR DESCRIPTION
Fix for https://github.com/TrashEmail/TrashEmail/issues/59 alternative to https://github.com/TrashEmail/TrashEmail/pull/62 Removed the two HTML file concept for now.